### PR TITLE
Conditionally include src/Util/main.sml.

### DIFF
--- a/src/Apps/Canon/canon.cm
+++ b/src/Apps/Canon/canon.cm
@@ -4,6 +4,5 @@ Group is
     canonOutput.sml
     canonHooks.sml
     canon.sml
-    ../../Util/main.sml
     ../../fxlib.cm
     $/basis.cm

--- a/src/Apps/Copy/copy.cm
+++ b/src/Apps/Copy/copy.cm
@@ -4,6 +4,5 @@ Group is
     copyOutput.sml
     copyHooks.sml
     copy.sml
-    ../../Util/main.sml
     ../../fxlib.cm
     $/basis.cm

--- a/src/Apps/Esis/esis.cm
+++ b/src/Apps/Esis/esis.cm
@@ -2,7 +2,6 @@ Group is
     esisOptions.sml
     esisOutput.sml
     esis.sml
-    ../../Util/main.sml
     esisHooks.sml
     esisData.sml
     ../../fxlib.cm

--- a/src/Apps/Null/null.cm
+++ b/src/Apps/Null/null.cm
@@ -2,7 +2,6 @@ Group is
     nullHooks.sml
     nullOptions.sml
     null.sml
-    ../../Util/main.sml
     nullHard.sml
     ../../fxlib.cm
     $/basis.cm

--- a/src/Apps/Viz/viz.cm
+++ b/src/Apps/Viz/viz.cm
@@ -1,7 +1,6 @@
 Group is
     vizOptions.sml
     viz.sml
-    ../../Util/main.sml
     vizHooks.sml
     ../../fxlib.cm
     $/basis.cm


### PR DESCRIPTION
in 13df14a3f75ee3d932d56e71502f1ffb08df9335 you added src/Util/main.sml to src/Apps/\*/\*.cm,
which breaks compilation on SML/NJ, with an error such as:
`src/Apps/Viz/viz.cm:4.5-4.24 Error: no module exports from src/Apps/Viz/(viz.cm):../../Util/main.sml`

If haven't fully grokked your particular of your build environment, so attempted to guess
at what might be an appropriate fix.

If you are converting from cm to polybuild, 
Could you define a PolyML variable like mlton's cm2mlb tool [here](https://github.com/MLton/mlton/blob/master/util/cm2mlb/cm2mlb.sml#L266), and [here](https://github.com/MLton/mlton/blob/master/util/cm2mlb/cm2mlb.sml#L145-L148)

Then the following snippet will be picked up in the .cm files (as is approach taken in the patch)
```
#if (defined(MLton) orelse defined(PolyML))
    ../../Util/main.sml
#endif
```

I only tested that this builds with the included Makefile, under smlnj,
by all means disregard if there is a more appropriate fix.